### PR TITLE
Support pluggable fork implementations

### DIFF
--- a/install
+++ b/install
@@ -1,33 +1,41 @@
 #!/usr/bin/env bash
 set -e
 #This is a fork of npiperelay that supports Assuan, the protocol that gpg-agent speaks
-NPRREPO="NZSmartie/npiperelay"
-NPRFILE="npiperelay.exe"
-NPRFILEURL="https://github.com/NZSmartie/npiperelay/releases/download/v0.1/npiperelay.exe"
+NPRREPO="ndimiduk/npiperelay"
+NPRFILE="npiperelay_windows_amd64.exe"
+NPRTAG="v1.6.0-libassuan-file-sockets-e9d23cb"
 
 usage() {
-	echo 'Usage: install [-hgv]'
+	echo 'Usage: install [-hgvrft]'
 	echo 'Install wsl-gpg-systemd automatically. See README for manual instructions.'
 	echo ''
 	echo '  -h, --help      this help'
 	echo '  -g, --gh        use GitHub CLI to fetch npiperelay, installing it first if necessary'
 	echo '  -v, --verbose   show verbose output when available'
+        echo "  -r, --repo      the github repo from which to download npiperelay. Default: $NPRREPO"
+        echo "  -f, --file      the npiperelay executable to download. Default: $NPRFILE"
+        echo "  -t, --tag       the release tag npiperelay to download. Default: $NPRTAG"
 	echo ''
-	exit $1
+	exit "$1"
 }
 
-opts=$(getopt -o 'ghv' --long 'gh,help,verbose' -n install -- "$@")
+opts=$(getopt -o 'hgvr:f:t:' --long 'help,gh,verbose,repo:,file:,tag:' -n install -- "$@")
 eval set -- "$opts"
 unset opts
 
 for opt; do
 	case "$opt" in
-		-g|--gh) usegh="true";;
-		-h|--help) usage;;
-		-v|--verbose) verbose="-v";;
+		-g|--gh) usegh="true";shift;;
+		-h|--help) usage 0;;
+		-v|--verbose) verbose="-v";shift;;
+                -r|--repo) NPRREPO="$2";shift 2;;
+                -f|--file) NPRFILE="$2";shift 2;;
+                -t|--tag) NPRTAG="$2";shift 2;;
 		*) break;;
 	esac
 done
+
+NPRFILEURL="https://github.com/${NPRREPO}/releases/download/${NPRTAG}/${NPRFILE}"
 
 #This is taken verbatim from the upstream installation instructions:
 #https://github.com/cli/cli/blob/trunk/docs/install_linux.md#debian-ubuntu-linux-raspberry-pi-os-apt
@@ -47,8 +55,8 @@ fixpath() {
 }
 
 enable_w32_ssh() {
-	gpgagentconf=$(wslpath -u $(gpgconf.exe --list-dirs homedir | fixpath))
-	grep -q enable-win32-openssh-support $gpgagentconf || printf 'enable-win32-openssh-support\r\n' >> $gpgagentconf
+	gpgagentconf="$(wslpath -u "$(gpgconf.exe --list-dirs homedir | fixpath)")"
+	grep -q enable-win32-openssh-support "$gpgagentconf" || printf 'enable-win32-openssh-support\r\n' >> "$gpgagentconf"
 	gpg-connect-agent.exe reloadagent /bye
 }
 
@@ -56,7 +64,8 @@ enable_w32_ssh() {
 #If you edit these, the install will not work.
 workdir="$(mktemp -p '' -d install-ssh-pageant-XXXX)"
 nprfile_w="${workdir}/$NPRFILE"
-gpgwinpath="$(gpgconf.exe --list-dirs agent-extra-socket | fixpath)"
+gpgwinpath="$(gpgconf.exe --list-dirs agent-socket | fixpath)"
+gpgwinpath_extra="$(gpgconf.exe --list-dirs agent-extra-socket | fixpath)"
 unitdir="${XDG_CONFIG_HOME:-$HOME/.config}/systemd/user"
 
 #You can edit these if you really want, but they are sensible defaults
@@ -69,22 +78,23 @@ nprwinpath_u="$(wslpath -u "$nprwinpath")"
 localbin="$HOME/.local/bin"
 nprlocalpath="${localbin}/$NPRFILE"
 
-printf 'Downloading %s...\n' "$NPRFILE"
-if [ $usegh ]; then
+printf 'Downloading %s:%s %s...\n' "$NPRREPO" "$NPRTAG" "$NPRFILE"
+if [ "$usegh" ]; then
 	hash gh 2>/dev/null || install_gh
-	gh release download -p $NPRFILE -R $NPRREPO -D "${workdir}"
+	gh release download -p "$NPRFILE" -R "$NPRREPO" -D "${workdir}" --clobber "$NPRTAG"
 else
 	curl -fsSL --output "${nprfile_w}" "$NPRFILEURL"
 fi
 
 printf 'Installing...\n'
 sed 's%^ExecStart=\%h/.local/bin/npiperelay.exe%ExecStart='"${nprlocalpath}"'%' systemd-units/gpg-agent-ssh@.service > "${workdir}/gpg-agent-ssh@.service"
-sed 's%^ExecStart=.*%ExecStart='"${nprlocalpath} -ep -ei -s -a '${gpgwinpath}'%" systemd-units/gpg-agent@.service > "${workdir}/gpg-agent@.service"
-cp systemd-units/gpg-agent-ssh.socket systemd-units/gpg-agent.socket "${workdir}/"
-install $verbose -D "${nprfile_w}" "${nprwinpath_u}" && rm "${nprfile_w}"
-install $verbose -Dm 644 -t "${unitdir}" $workdir/*
-install $verbose -d "${localbin}"
-ln $verbose -nfs "${nprwinpath_u}" "${localbin}"
+sed 's%^ExecStart=.*%ExecStart='"${nprlocalpath} -v -bg -ep -ei -s -a '${gpgwinpath}'%" systemd-units/gpg-agent@.service > "${workdir}/gpg-agent@.service"
+sed 's%^ExecStart=.*%ExecStart='"${nprlocalpath} -v -bg -ep -ei -s -a '${gpgwinpath_extra}'%" systemd-units/gpg-agent-extra@.service > "${workdir}/gpg-agent-extra@.service"
+cp systemd-units/gpg-agent-ssh.socket systemd-units/gpg-agent.socket systemd-units/gpg-agent-extra.socket "${workdir}/"
+install "$verbose" -D "${nprfile_w}" "${nprwinpath_u}" && rm "${nprfile_w}"
+install "$verbose" -Dm 644 -t "${unitdir}" "$workdir"/*
+install "$verbose" -d "${localbin}"
+ln "$verbose" -nfs "${nprwinpath_u}" "${localbin}"
 
 rm -r "${workdir}"
 

--- a/systemd-units/gpg-agent-extra.socket
+++ b/systemd-units/gpg-agent-extra.socket
@@ -1,9 +1,9 @@
 [Unit]
-Description=GnuPG cryptographic agent and passphrase cache (S.gpg-agent)
+Description=GnuPG cryptographic agent and passphrase cache (S.gpg-agent.extra)
 Documentation=man:gpg-agent(1)
 
 [Socket]
-ListenStream=%t/gnupg/S.gpg-agent
+ListenStream=%t/gnupg/S.gpg-agent.extra
 SocketMode=0600
 DirectoryMode=0700
 Accept=true

--- a/systemd-units/gpg-agent-extra@.service
+++ b/systemd-units/gpg-agent-extra@.service
@@ -1,0 +1,12 @@
+[Unit]
+Description=gpg4win to WSL connector for GPG (S.gpg-agent.extra)
+Requires=gpg-agent-extra.socket
+
+[Service]
+Type=simple
+ExecStart=%h/.local/bin/npiperelay.exe -v -p -ep -ei -s -a 'C:/Users/alexm/AppData/Local/gnupg/S.gpg-agent.extra'
+StandardInput=socket
+StandardError=journal
+
+[Install]
+WantedBy=default.target

--- a/systemd-units/gpg-agent-ssh@.service
+++ b/systemd-units/gpg-agent-ssh@.service
@@ -4,8 +4,9 @@ Requires=gpg-agent-ssh.socket
 
 [Service]
 Type=simple
-ExecStart=%h/.local/bin/npiperelay.exe -ei -s '//./pipe/openssh-ssh-agent'
+ExecStart=%h/.local/bin/npiperelay.exe -v -p -ei -s '//./pipe/openssh-ssh-agent'
 StandardInput=socket
+StandardError=journal
 
 [Install]
 WantedBy=default.target

--- a/systemd-units/gpg-agent@.service
+++ b/systemd-units/gpg-agent@.service
@@ -1,11 +1,12 @@
 [Unit]
-Description=gpg4win to WSL connector for GPG
+Description=gpg4win to WSL connector for GPG (S.gpg-agent)
 Requires=gpg-agent.socket
 
 [Service]
 Type=simple
-ExecStart=%h/.local/bin/npiperelay.exe -ep -ei -s -a 'C:/Users/alexm/AppData/Local/gnupg/S.gpg-agent.extra'
+ExecStart=%h/.local/bin/npiperelay.exe -v -p -ep -ei -s -a 'C:/Users/alexm/AppData/Local/gnupg/S.gpg-agent'
 StandardInput=socket
+StandardError=journal
 
 [Install]
 WantedBy=default.target


### PR DESCRIPTION
This change is based on my recent experience getting `gpg-agent` and `ssh-agent` forwarding working with WSL2 and Ubuntu. It goes along with my fork of a fork of the `npiperelay` repository, which applies the original libassuan changes and applies them onto `@albertony`'s general improvements.

See also https://github.com/ndimiduk/npiperelay/tree/libassuan-file-sockets

* support dynamically specifying the source for npiperelay
* add separate units for S.gpg-agent and S.gpg-agent.extra
* service units redirect stderr to the journal
* clean up shellcheck warnings